### PR TITLE
Fixes for Firefox on Android

### DIFF
--- a/appinfo/remote.php
+++ b/appinfo/remote.php
@@ -17,9 +17,8 @@ if(!$urlParser->isValid()) {
   exit();
 }
 
-OCA_mozilla_sync\Utils::generateMozillaTimestamp();
-
 if($service === 'userapi') {
+  OCA_mozilla_sync\Utils::generateMozillaTimestamp();
   $userService = new OCA_mozilla_sync\UserService($urlParser);
   $userService->run();
 }


### PR DESCRIPTION
Major changes to make mozilla_sync work in combination with Firefox on Android.
These include implementing all specified output formats and adding additional Weave headers.

Fixes owncloud/apps#826
Fixes owncloud/apps#1163
