### PR TITLE
Fix PHP 5.3 compatibility

### DIFF
--- a/lib/storageservice.php
+++ b/lib/storageservice.php
@@ -315,7 +315,8 @@ class StorageService extends Service
 			return false;
 		}
 
-		$size = ((float) ($result->fetchRow()['size']))/1000.0;
+		$row = $result->fetchRow();
+		$size = ((float) ($row['size']))/1000.0;
 
 		OutputData::write(array($size, null));
 		return true;


### PR DESCRIPTION
PHP 5.3 does not allow to directly access an array returned by a function call.

Should solve #6
