### PR TITLE
Omit unnecessary JSON fields in response

### DIFF
--- a/lib/storageservice.php
+++ b/lib/storageservice.php
@@ -379,7 +379,7 @@ class StorageService extends Service
 		// full or id modifier
 		$queryFields = '';
 		if(isset($modifiers['full'])) {
-			$queryFields = '`payload`, `name` AS `id`, `modified`, `parentid`, `predecessorid`, `sortindex`, `ttl`';
+			$queryFields = '`payload`, `name` AS `id`, `modified`, `sortindex`';
 		}
 		else{
 			$queryFields = '`name` AS `id`';


### PR DESCRIPTION
Don't return predecessorid, parentid and ttl fields in response.
predecessorid and parentid are deprecated [1], ttl is not supposed to be
returned by the Sync server [2].

[1] https://docs.services.mozilla.com/storage/apis-1.1.html#id5
[2]
http://hg.mozilla.org/mozilla-central/file/632e3a94bd22/mobile/android/base/sync/CryptoRecord.java#l168
