### PR TITLE
Cast numRows() to int before comparing identity

### DIFF
--- a/lib/storageservice.php
+++ b/lib/storageservice.php
@@ -313,7 +313,7 @@ class StorageService extends Service
 									ON *PREFIX*mozilla_sync_wbo.collectionid = *PREFIX*mozilla_sync_collections.id WHERE userid = ?');
 		$result = $query->execute( array($userId) );
 
-		if($result == false || $result->numRows() != 1) {
+		if($result == false || ((int) $result->numRows()) !== 1) {
 			return false;
 		}
 

--- a/lib/user.php
+++ b/lib/user.php
@@ -122,7 +122,7 @@ class User
 		$query = \OCP\DB::prepare( 'SELECT 1 FROM `*PREFIX*mozilla_sync_users` WHERE `sync_user` = ?');
 		$result = $query->execute( array($userHash) );
 
-		return $result->numRows() === 1;
+		return ((int) $result->numRows()) === 1;
 	}
 
 	/**


### PR DESCRIPTION
For some configurations (e.g. Mysql 5.5.31, PHP 5.4.4) , numRows() returns a string instead of an int.
Casting it to int before comparing using === or !== removes this issue.

See commit 952414dba7bc8ca and issue #11.
