### PR TITLE
DB: Use LENGTH() function instead of CHAR_LENGTH()

### DIFF
--- a/lib/storage.php
+++ b/lib/storage.php
@@ -411,6 +411,10 @@ class Storage
 	/**
 	* @brief Get the size of each collection for a user.
 	*
+	* Returns the size of each collection for a specific user in kB. For SQLite
+	*	the number of thousand characters are returned, since there is no byte length
+	*	function for SQLite databases.
+	*
 	* @param string $syncId The Sync user whose collection sizes are returned,
 	* the logged in user by default.
 	* @return mixed Array of collection => size in kB for the specified user.
@@ -427,7 +431,7 @@ class Storage
 			return false;
 		}
 
-		$query = \OCP\DB::prepare('SELECT name, (SELECT SUM(CHAR_LENGTH(payload))
+		$query = \OCP\DB::prepare('SELECT name, (SELECT SUM(LENGTH(payload))
 			FROM *PREFIX*mozilla_sync_wbo WHERE
 			*PREFIX*mozilla_sync_wbo.collectionid =
 			*PREFIX*mozilla_sync_collections.id) as size FROM

--- a/lib/user.php
+++ b/lib/user.php
@@ -437,6 +437,9 @@ class User
 	/**
 	* @brief Gets the usage for the given user.
 	*
+	* Returns the current usage for a specific user in kB. For SQLite
+	* the number of thousand characters are returned, since there is no byte length
+	* function for SQLite databases.
 	* It is possible to restrict the quota of Mozilla Sync to a limit. A zero
 	* limit results in no restriction. The value is zero by default but can be
 	* set on the admin page.
@@ -446,7 +449,7 @@ class User
 	*/
 	public static function getUserUsage($syncId) {
 		// Sum up character size of all WBO
-		$query = \OCP\DB::prepare('SELECT SUM(CHAR_LENGTH(`payload`)) as `size`
+		$query = \OCP\DB::prepare('SELECT SUM(LENGTH(`payload`)) as `size`
 				FROM `*PREFIX*mozilla_sync_wbo` JOIN
 				`*PREFIX*mozilla_sync_collections` ON
 				`*PREFIX*mozilla_sync_wbo`.`collectionid` =


### PR DESCRIPTION
Use `LENGTH()` instead of `CHAR_LENGTH()` to get the size of
database entries. The latter is not supported in SQLite. The former,
however, returns the number of characters in SQLite instead of the
number of bytes as specified in the SQL standard.

Fixes #47.
