### PR TITLE
DB: Use precision and scale instead of length for decimal

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -145,7 +145,8 @@
         <type>decimal</type>
         <notnull>true</notnull>
         <default>0.00</default>
-        <length>15</length>
+        <precision>12</precision>
+        <scale>2</scale>
       </field>
 
       <field>

--- a/lib/storage.php
+++ b/lib/storage.php
@@ -54,7 +54,7 @@ class Storage
 	*/
 	static public function deleteOldWbo() {
 		$query = \OCP\DB::prepare('DELETE FROM `*PREFIX*mozilla_sync_wbo` WHERE
-			`ttl` > 0 AND (`modified` + `ttl`) < CAST(? AS DECIMAL(15,2))');
+			`ttl` > 0 AND (`modified` + `ttl`) < CAST(? AS DECIMAL(12,2))');
 		$result = $query->execute(array(Utils::getMozillaTimestamp()));
 
 		if ($result == false) {
@@ -271,10 +271,10 @@ class Storage
 
 		// Time modifiers
 		if (isset($modifiers['older'])) {
-			$whereString .= ' AND `modified` <= CAST( ? AS DECIMAL(15,2))';
+			$whereString .= ' AND `modified` <= CAST( ? AS DECIMAL(12,2))';
 			$queryArgs[] = $modifiers['older'];
 		} else if (isset($modifiers['newer'])) {
-			$whereString .= ' AND `modified` >= CAST( ? AS DECIMAL(15,2))';
+			$whereString .= ' AND `modified` >= CAST( ? AS DECIMAL(12,2))';
 			$queryArgs[] = $modifiers['newer'];
 		} else if (isset($modifiers['index_above'])) {
 			$whereString .= ' AND `sortindex` >= ?';


### PR DESCRIPTION
Use precision and scale for oc_mozilla_sync_wbo.modified column. Make it
DECIMAL(12,2).

See #71
