### PR TITLE
Foxbrowser fixes

### DIFF
--- a/lib/urlparser.php
+++ b/lib/urlparser.php
@@ -30,6 +30,9 @@ class UrlParser {
 		// Parser is valid at the begining
 		$this->parseValidFlag = true;
 
+		// Foxbrowser workaround
+		$url = str_replace('/?', '?', $url);
+
 		// Remove '/' from beginning and end
 		$url = trim($url, '/');
 

--- a/lib/user.php
+++ b/lib/user.php
@@ -194,8 +194,11 @@ class User
 	public static function authenticateUser($syncHash) {
 
 		if (!isset($_SERVER['PHP_AUTH_USER'])) {
-			Utils::writeLog("No HTTP authentication header sent.");
-			return false;
+			Utils::writeLog("No HTTP authentication header sent.", \OCP\Util::WARN);
+			// Send 'authentication needed' header for Foxbrowser
+			header("WWW-Authenticate: Basic");
+			Utils::changeHttpStatus(Utils::STATUS_INVALID_USER);
+			exit();
 		}
 
 		// Sync hash URL parameter and HTTP Authentication header user name do not match


### PR DESCRIPTION
Foxbrowser does not send a username and password in its first request. Only upon responding with a `WWW-Authenticate: Basic` header the client sends the username and password in the following request. Additionally, Foxbrowser sends requests for URLs like `http://example.com/storage/collection/?full=1`. This fix removes the trailing slash before the question mark to allow for correct parsing.

Closes #24.
