### PR TITLE
Remove OC_Apps::loadsApps() call

### DIFF
--- a/lib/user.php
+++ b/lib/user.php
@@ -246,8 +246,7 @@ class User
 	*/
 	private static function checkPassword($userName, $password) {
 
-		// Enable authentication app, necessary for LDAP to work
-		\OC_App::loadApps(array('authentication'));
+		// NOTE: Since ownCloud 7 authentication apps are loaded automatically
 
 		// Check if user is allowed to use Mozilla Sync
 		if (self::checkUserIsAllowed($userName) === false) {


### PR DESCRIPTION
`OC_Apps::loadApps()` is not allowed anymore in the latest ownCloud
master. To still allow for authentication with LDAP user backend, the
authentication type was added to the `info.xml`.

Fixes #90.
