### PR TITLE
Don't output wrong errors in the log

### DIFF
--- a/lib/inputdata.php
+++ b/lib/inputdata.php
@@ -36,7 +36,7 @@ class InputData implements \arrayaccess
 
 		$parseResult = json_decode($input, true);
 
-		if ($parseResult == null) {
+		if (is_null($parseResult)) {
 			$this->parseValidFlag = false;
 		} else {
 			$this->inputArray = $parseResult;

--- a/lib/service.php
+++ b/lib/service.php
@@ -19,7 +19,7 @@ abstract class Service
 	abstract public function run();
 
 	protected function getInputData() {
-		if ($this->inputData == null) {
+		if (is_null($this->inputData)) {
 			$this->inputData = new InputData();
 		}
 		return $this->inputData;

--- a/lib/storage.php
+++ b/lib/storage.php
@@ -40,7 +40,7 @@ class Storage
 
 		// Creation of collection failed
 		if ($result == false) {
-			Utils::writeLog("DB: Could not create collection " . $collectionName . ".");
+			Utils::writeLogDbError("DB: Could not create collection " . $collectionName . ".", $query);
 			return false;
 		}
 
@@ -107,7 +107,7 @@ class Storage
 		$result = $query->execute(array($collectionId, $wboId));
 
 		if ($result == false) {
-			Utils::writeLog("DB: Could not delete WBO " . $wboId . ".", \OCP\Util::INFO);
+			Utils::writeLogDbError("DB: Could not delete WBO " . $wboId . ".", $query, \OCP\Util::INFO);
 			return false;
 		}
 
@@ -147,7 +147,7 @@ class Storage
 		$result = $query->execute($queryArgs);
 
 		if ($result == false) {
-			Utils::writeLog("DB: Could not insert WBO for user " . $syncId . " in collection " . $collectionId . ".");
+			Utils::writeLogDbError("DB: Could not insert WBO for user " . $syncId . " in collection " . $collectionId . ".", $query);
 			return false;
 		}
 
@@ -184,7 +184,7 @@ class Storage
 		$result = $query->execute($queryArgs);
 
 		if ($result == false) {
-			Utils::writeLog("DB: Could not update WBO for user " . $syncId . " in collection " . $collectionId . ".");
+			Utils::writeLogDbError("DB: Could not update WBO for user " . $syncId . " in collection " . $collectionId . ".", $query);
 			return false;
 		}
 
@@ -205,7 +205,7 @@ class Storage
 		$result = $query->execute(array($syncId));
 
 		if ($result == false) {
-			Utils::writeLog("DB: Could not delete storage for user " . $syncId . ".");
+			Utils::writeLogDbError("DB: Could not delete storage for user " . $syncId . ".", $query);
 			return false;
 		}
 
@@ -215,7 +215,7 @@ class Storage
 		$result = $query->execute(array($syncId));
 
 		if ($result == false) {
-			Utils::writeLog("DB: Could not delete collections for user " . $syncId . ".");
+			Utils::writeLogDbError("DB: Could not delete collections for user " . $syncId . ".", $query);
 			return false;
 		}
 
@@ -361,8 +361,8 @@ class Storage
 		$result = $query->execute(array($syncId));
 
 		if ($result == false) {
-			Utils::writeLog("DB: Could not get info collections for user " .
-			$syncId . ".");
+			Utils::writeLogDbError("DB: Could not get info collections for user " .
+			$syncId . ".", $query);
 			return false;
 		}
 
@@ -441,8 +441,8 @@ class Storage
 		$result = $query->execute(array($syncId));
 
 		if ($result == false) {
-			Utils::writeLog("DB: Could not get info collection usage for user "
-			. $syncId . ".");
+			Utils::writeLogDbError("DB: Could not get info collection usage for user "
+			. $syncId . ".", $query);
 			return false;
 		}
 
@@ -487,8 +487,8 @@ class Storage
 		$result = $query->execute(array('clients', $syncId));
 
 		if ($result === false) {
-			Utils::writeLog("DB: Could not get number of clients for user " .
-			$syncId . ".");
+			Utils::writeLogDbError("DB: Could not get number of clients for user " .
+			$syncId . ".", $query);
 			return false;
 		}
 

--- a/lib/storage.php
+++ b/lib/storage.php
@@ -39,7 +39,7 @@ class Storage
 		$result = $query->execute(array($syncId, $collectionName));
 
 		// Creation of collection failed
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not create collection " . $collectionName . ".", $query);
 			return false;
 		}
@@ -57,7 +57,7 @@ class Storage
 			`ttl` > 0 AND (`modified` + `ttl`) < CAST(? AS DECIMAL(15,2))');
 		$result = $query->execute(array(Utils::getMozillaTimestamp()));
 
-		if ($result == false) {
+		if ($result === false) {
 			// Also returns false when no old WBO was found -> don't Utils::writeLog() as it would spam the log
 			return false;
 		}
@@ -86,7 +86,7 @@ class Storage
 		$result = $query->execute(array($collectionId, $wboArray['id']));
 
 		// No WBO found, add a new one
-		if ($result->fetchRow() == false) {
+		if (is_null($result->fetchRow())) {
 			return self::insertWBO($syncId, $modifiedTime, $collectionId, $wboArray);
 		} else {
 			return self::updateWBO($syncId, $modifiedTime, $collectionId, $wboArray);
@@ -106,7 +106,7 @@ class Storage
 			WHERE `collectionid` = ? AND `name` = ?');
 		$result = $query->execute(array($collectionId, $wboId));
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not delete WBO " . $wboId . ".", $query, \OCP\Util::INFO);
 			return false;
 		}
@@ -146,7 +146,7 @@ class Storage
 		$query = \OCP\DB::prepare($queryString);
 		$result = $query->execute($queryArgs);
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not insert WBO for user " . $syncId . " in collection " . $collectionId . ".", $query);
 			return false;
 		}
@@ -183,7 +183,7 @@ class Storage
 		$query = \OCP\DB::prepare($queryString);
 		$result = $query->execute($queryArgs);
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not update WBO for user " . $syncId . " in collection " . $collectionId . ".", $query);
 			return false;
 		}
@@ -204,7 +204,7 @@ class Storage
 			WHERE `userid` = ?)');
 		$result = $query->execute(array($syncId));
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not delete storage for user " . $syncId . ".", $query);
 			return false;
 		}
@@ -214,7 +214,7 @@ class Storage
 			WHERE `userid` = ?');
 		$result = $query->execute(array($syncId));
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not delete collections for user " . $syncId . ".", $query);
 			return false;
 		}
@@ -238,7 +238,7 @@ class Storage
 
 		// IDs
 		if (isset($modifiers['ids'])) {
-			if (gettype($modifiers['ids']) == 'array') {
+			if (gettype($modifiers['ids']) === 'array') {
 				$first = true;
 				$whereString .= ' AND (';
 				foreach ($modifiers['ids'] as $value) {
@@ -286,11 +286,11 @@ class Storage
 
 		// Sort
 		if (isset($modifiers['sort'])) {
-			if ($modifiers['sort'] == 'oldest') {
+			if ($modifiers['sort'] === 'oldest') {
 				$whereString .= ' ORDER BY `modified` ASC';
-			} else if ($modifiers['sort'] == 'newest') {
+			} else if ($modifiers['sort'] === 'newest') {
 				$whereString .= ' ORDER BY `modified` DESC';
-			} else if ($modifiers['sort'] == 'index') {
+			} else if ($modifiers['sort'] === 'index') {
 				$whereString .= ' ORDER BY `sortindex` DESC';
 			}
 		}
@@ -360,7 +360,7 @@ class Storage
 			`*PREFIX*mozilla_sync_collections` WHERE `userid` = ?');
 		$result = $query->execute(array($syncId));
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not get info collections for user " .
 			$syncId . ".", $query);
 			return false;
@@ -371,7 +371,7 @@ class Storage
 		while (($row = $result->fetchRow())) {
 
 			// Skip empty collections
-			if ($row['modified'] == null) {
+			if (is_null($row['modified'])) {
 				continue;
 			}
 
@@ -440,7 +440,7 @@ class Storage
 			*PREFIX*mozilla_sync_collections WHERE userid = ?');
 		$result = $query->execute(array($syncId));
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not get info collection usage for user "
 			. $syncId . ".", $query);
 			return false;
@@ -451,7 +451,7 @@ class Storage
 		while (($row = $result->fetchRow())) {
 
 			// Skip empty collections
-			if ($row['size'] == null) {
+			if (is_null($row['size'])) {
 				continue;
 			}
 

--- a/lib/storageservice.php
+++ b/lib/storageservice.php
@@ -45,7 +45,7 @@ class StorageService extends Service
 
 		// Convert Sync hash to Sync ID
 		$syncId = User::syncHashToSyncId($syncHash);
-		if ($syncId == false) {
+		if ($syncId === false) {
 			Utils::changeHttpStatus(Utils::STATUS_INVALID_USER);
 			Utils::writeLog("Could not convert user " . $syncHash . " to Sync ID.");
 			return false;
@@ -57,8 +57,8 @@ class StorageService extends Service
 		// Map request to functions
 
 		// Info case: https://server/pathname/version/username/info/
-		if (($this->urlParser->commandCount() == 2) &&
-				($this->urlParser->getCommand(0) == 'info')) {
+		if (($this->urlParser->commandCount() === 2) &&
+				($this->urlParser->getCommand(0) === 'info')) {
 
 			if (Utils::getRequestMethod() != 'GET') {
 				Utils::changeHttpStatus(Utils::STATUS_NOT_FOUND);
@@ -79,8 +79,8 @@ class StorageService extends Service
 		}
 
 		// Storage case: https://server/pathname/version/username/storage/
-		else if (($this->urlParser->commandCount() == 1) &&
-				($this->urlParser->getCommand(0) == 'storage')) {
+		else if (($this->urlParser->commandCount() === 1) &&
+				($this->urlParser->getCommand(0) === 'storage')) {
 
 			switch (Utils::getRequestMethod()) {
 				case 'DELETE': $this->deleteStorage($syncId); break;
@@ -92,8 +92,8 @@ class StorageService extends Service
 		}
 
 		// Collection case: https://server/pathname/version/username/storage/collection
-		else if (($this->urlParser->commandCount() == 2) &&
-				($this->urlParser->getCommand(0) == 'storage')) {
+		else if (($this->urlParser->commandCount() === 2) &&
+				($this->urlParser->getCommand(0) === 'storage')) {
 
 			$collectionName = $this->urlParser->getCommand(1);
 			$modifiers = $this->urlParser->getCommandModifiers(1);
@@ -112,8 +112,8 @@ class StorageService extends Service
 		}
 
 		// WBO case: https://server/pathname/version/username/storage/collection/id
-		else if (($this->urlParser->commandCount() == 3) &&
-				($this->urlParser->getCommand(0) == 'storage')) {
+		else if (($this->urlParser->commandCount() === 3) &&
+				($this->urlParser->getCommand(0) === 'storage')) {
 
 			$collectionName = $this->urlParser->getCommand(1);
 			$wboId = $this->urlParser->getCommand(2);
@@ -254,7 +254,7 @@ class StorageService extends Service
 			`*PREFIX*mozilla_sync_collections` WHERE `userid` = ?');
 		$result = $query->execute(array($syncId));
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not get info collection counts for user "
 			. $syncId . ".", $query);
 			return false;
@@ -265,7 +265,7 @@ class StorageService extends Service
 		while (($row = $result->fetchRow())) {
 
 			// Skip empty collections
-			if ($row['counts'] == null) {
+			if (is_null($row['counts'])) {
 				continue;
 			}
 
@@ -407,7 +407,7 @@ class StorageService extends Service
 			' FROM `*PREFIX*mozilla_sync_wbo` ' . $whereString, $limit, $offset);
 		$result = $query->execute($queryArgs);
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not get collection " . $collectionId . "
 			for user " . $syncId . ".", $query);
 			return false;
@@ -518,10 +518,10 @@ class StorageService extends Service
 		$whereString .= Storage::modifiersToString($modifiers, $queryArgs, $limit, $offset);
 
 		// Delete all WBO of a collection
-		$query = \OCP\DB::prepare( 'DELETE FROM `*PREFIX*mozilla_sync_wbo` ' . $whereString, $limit, $offset );
-		$result = $query->execute( $queryArgs );
+		$query = \OCP\DB::prepare('DELETE FROM `*PREFIX*mozilla_sync_wbo` ' . $whereString, $limit, $offset);
+		$result = $query->execute($queryArgs);
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Failed to delete WBO for collection " .
 			$collectionId . " for user " . $syncId . ".", $query);
 			return false;
@@ -533,12 +533,11 @@ class StorageService extends Service
 		$result = $query->execute(array($collectionId));
 
 		// No WBO found, delete entire collection
-		if ($result->fetchRow() == false) {
-			$query = \OCP\DB::prepare('DELETE FROM
-			`*PREFIX*mozilla_sync_collections` WHERE `id` = ?');
+		if ($result->fetchRow() === false) {
+			$query = \OCP\DB::prepare('DELETE FROM `*PREFIX*mozilla_sync_collections` WHERE `id` = ?');
 			$result = $query->execute(array($collectionId));
 
-			if ($result == false) {
+			if ($result === false) {
 				Utils::writeLogDbError("DB: Failed to delete collection " .
 				$collectionId . " for user " . $syncId . ".", $query);
 				return false;
@@ -566,14 +565,14 @@ class StorageService extends Service
 			`collectionid` = ? AND `name` = ?');
 		$result = $query->execute(array($collectionId, $wboId));
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Failed to get WBO " . $wboId . " of collection	"
 			. $collectionId . " for user " . $syncId . ".", $query);
 			return false;
 		}
 
 		$row = $result->fetchRow();
-		if ($row == false) {
+		if (is_null($row)) {
 			Utils::changeHttpStatus(Utils::STATUS_NOT_FOUND);
 			Utils::writeLog("DB: Could not find requested WBO " . $wboId .
 			" of collection " . $collectionId . " for user " . $syncId . ".", \OCP\Util::WARN);
@@ -604,7 +603,7 @@ class StorageService extends Service
 		// Get and validate input data
 		$inputData = $this->getInputData();
 		if ((!$inputData->isValid()) &&
-				(count($inputData->getInputArray()) == 1)) {
+				(count($inputData->getInputArray()) === 1)) {
 			Utils::changeHttpStatus(Utils::STATUS_INVALID_DATA);
 			Utils::writeLog("URL: Invalid input data for putting WBO " . $wboId
 			. " of collection " . $collectionId . " for user " . $syncId . ".");
@@ -627,7 +626,7 @@ class StorageService extends Service
 		$result = Storage::saveWBO($syncId, $modifiedTime, $collectionId,
 			$inputData->getInputArray());
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLog("Failed to save WBO " . $wboId . " of collection " .
 			$collectionId . " for user " . $syncId . ".");
 			return false;
@@ -651,7 +650,7 @@ class StorageService extends Service
 
 		$result = Storage::deleteWBO($syncId, $collectionId, $wboId);
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLog("Failed to delete WBO " . $wboId . " of collection "
 			. $collectionId . " for user " . $syncId . ".");
 			return false;
@@ -682,7 +681,7 @@ class StorageService extends Service
 
 		$result = Storage::deleteStorage($syncId);
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLog("Failed to delete all records for user " . $syncId . ".");
 			return false;
 		}

--- a/lib/storageservice.php
+++ b/lib/storageservice.php
@@ -255,8 +255,8 @@ class StorageService extends Service
 		$result = $query->execute(array($syncId));
 
 		if ($result == false) {
-			Utils::writeLog("DB: Could not get info collection counts for user "
-			. $syncId . ".");
+			Utils::writeLogDbError("DB: Could not get info collection counts for user "
+			. $syncId . ".", $query);
 			return false;
 		}
 
@@ -408,8 +408,8 @@ class StorageService extends Service
 		$result = $query->execute($queryArgs);
 
 		if ($result == false) {
-			Utils::writeLog("DB: Could not get collection " . $collectionId . "
-			for user " . $syncId . ".");
+			Utils::writeLogDbError("DB: Could not get collection " . $collectionId . "
+			for user " . $syncId . ".", $query);
 			return false;
 		}
 
@@ -522,8 +522,8 @@ class StorageService extends Service
 		$result = $query->execute( $queryArgs );
 
 		if ($result == false) {
-			Utils::writeLog("DB: Failed to delete WBO for collection " .
-			$collectionId . " for user " . $syncId . ".");
+			Utils::writeLogDbError("DB: Failed to delete WBO for collection " .
+			$collectionId . " for user " . $syncId . ".", $query);
 			return false;
 		}
 
@@ -539,8 +539,8 @@ class StorageService extends Service
 			$result = $query->execute(array($collectionId));
 
 			if ($result == false) {
-				Utils::writeLog("DB: Failed to delete collection " .
-				$collectionId . " for user " . $syncId . ".");
+				Utils::writeLogDbError("DB: Failed to delete collection " .
+				$collectionId . " for user " . $syncId . ".", $query);
 				return false;
 			}
 		}
@@ -567,8 +567,8 @@ class StorageService extends Service
 		$result = $query->execute(array($collectionId, $wboId));
 
 		if ($result == false) {
-			Utils::writeLog("DB: Failed to get WBO " . $wboId . " of collection	"
-			. $collectionId . " for user " . $syncId . ".");
+			Utils::writeLogDbError("DB: Failed to get WBO " . $wboId . " of collection	"
+			. $collectionId . " for user " . $syncId . ".", $query);
 			return false;
 		}
 

--- a/lib/storageservice.php
+++ b/lib/storageservice.php
@@ -96,7 +96,7 @@ class StorageService extends Service
 				($this->urlParser->getCommand(0) === 'storage')) {
 
 			$collectionName = $this->urlParser->getCommand(1);
-			$modifiers = $this->urlParser->getCommandModifiers(1);
+			$modifiers = $this->urlParser->getCommandModifiers();
 
 			$collectionId = Storage::collectionNameToIndex($syncId, $collectionName);
 

--- a/lib/urlparser.php
+++ b/lib/urlparser.php
@@ -137,7 +137,7 @@ class UrlParser {
 			$key = $tmpArray[0];
 
 			// Split argument list
-			if (strpos($tmpArray[1], ',') == false) {
+			if (strpos($tmpArray[1], ',') === false) {
 				$value = $tmpArray[1];
 			} else {
 				$value = explode(',', $tmpArray[1]);

--- a/lib/user.php
+++ b/lib/user.php
@@ -154,7 +154,7 @@ class User
 		$result = $query->execute(array($userName, $syncHash));
 
 		if ($result == false) {
-			Utils::writeLog("DB: Could not create user " . $userName . " with Sync hash " . $syncHash . ".");
+			Utils::writeLogDbError("DB: Could not create user " . $userName . " with Sync hash " . $syncHash . ".", $query);
 			return false;
 		}
 
@@ -173,7 +173,7 @@ class User
 		$result = $query->execute(array($syncId));
 
 		if ($result == false) {
-			Utils::writeLog("DB: Could not delete user with Sync ID " . $syncId . ".");
+			Utils::writeLogDbError("DB: Could not delete user with Sync ID " . $syncId . ".", $query);
 			return false;
 		}
 
@@ -498,7 +498,7 @@ class User
 		$result = $query->execute(array($syncId));
 
 		if ($result == false) {
-			Utils::writeLog("DB: Could not get info quota for user " . $syncId . ".");
+			Utils::writeLogDbError("DB: Could not get info quota for user " . $syncId . ".", $query);
 			return false;
 		}
 

--- a/lib/user.php
+++ b/lib/user.php
@@ -153,7 +153,7 @@ class User
 			(`username`, `sync_user`) VALUES (?, ?)' );
 		$result = $query->execute(array($userName, $syncHash));
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not create user " . $userName . " with Sync hash " . $syncHash . ".", $query);
 			return false;
 		}
@@ -172,7 +172,7 @@ class User
 			WHERE `id` = ?');
 		$result = $query->execute(array($syncId));
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not delete user with Sync ID " . $syncId . ".", $query);
 			return false;
 		}
@@ -497,7 +497,7 @@ class User
 		$query = \OCP\DB::prepare('SELECT SUM(LENGTH(`payload`)) as `size` FROM `*PREFIX*mozilla_sync_wbo` JOIN `*PREFIX*mozilla_sync_collections` ON `*PREFIX*mozilla_sync_wbo`.`collectionid` = `*PREFIX*mozilla_sync_collections`.`id` WHERE `userid` = ?');
 		$result = $query->execute(array($syncId));
 
-		if ($result == false) {
+		if ($result === false) {
 			Utils::writeLogDbError("DB: Could not get info quota for user " . $syncId . ".", $query);
 			return false;
 		}

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -23,9 +23,29 @@ class Utils
 		// Prepend file name, line number, calling function to debug output
 		$bt = debug_backtrace();
 		$caller = $bt[1];
+
+		// If called by writeLogDbError(), go back one further in the backtrace
+		if ($caller["function"] === "writeLogDbError") {
+			$caller = $bt[2];
+		}
+
 		$output = basename($caller["file"]) . "#" . $caller["line"] . " " . $caller["function"] . "():  " . $output;
 
 		\OCP\Util::writeLog("mozilla_sync", $output, $level);
+	}
+
+	/**
+	* @brief Writes debug output including additional SQL error info to the	ownCloud log.
+	*
+	* @param string $output The string appended to ownCloud log.
+	* @param \Doctrine\DBAL\Driver\Statement $query The query whose information
+	*	will be added to the debug output.
+	* @param int $level Log level of debug output. Default is \OCP\Util::ERROR.
+	*/
+	public static function writeLogDbError($output, $query, $level = \OCP\Util::ERROR) {
+		$output = $output . " SQLSTATE: " . $query->errorCode() . ". Error info: " . var_export($query->errorInfo(), true);
+
+		self::writeLog($output, $level);
 	}
 
 	/**


### PR DESCRIPTION
- Output the SQLSTATE and the database error info to logs for database errors.
- Avoid comparing with `==`, always use `===` to make sure the result is interpreted correctly.
- Make URL parsing more robust by relying on PHP's `parse_url()`.

Fixes #49.
Fixes #87.
