### PR TITLE
Use correct === instead of is_null()

### DIFF
--- a/lib/storage.php
+++ b/lib/storage.php
@@ -86,7 +86,7 @@ class Storage
 		$result = $query->execute(array($collectionId, $wboArray['id']));
 
 		// No WBO found, add a new one
-		if (is_null($result->fetchRow())) {
+		if ($result->fetchRow() === false) {
 			return self::insertWBO($syncId, $modifiedTime, $collectionId, $wboArray);
 		} else {
 			return self::updateWBO($syncId, $modifiedTime, $collectionId, $wboArray);

--- a/lib/storageservice.php
+++ b/lib/storageservice.php
@@ -572,7 +572,7 @@ class StorageService extends Service
 		}
 
 		$row = $result->fetchRow();
-		if (is_null($row)) {
+		if ($row === false) {
 			Utils::changeHttpStatus(Utils::STATUS_NOT_FOUND);
 			Utils::writeLog("DB: Could not find requested WBO " . $wboId .
 			" of collection " . $collectionId . " for user " . $syncId . ".", \OCP\Util::WARN);


### PR DESCRIPTION
When checking if a WBO is already in the database, use the correct `
fetchRow() === false` instead of `is_null()`. The function
`fetchRow()` returns the boolean `false` when no (more) row(s)
are in the result set.

Fixes #97.
