### PR TITLE
Auto account creation

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -12,6 +12,7 @@ $tmpl = new \OCP\Template('mozilla_sync', 'admin');
 
 $tmpl->assign('mozillaSyncRestrictGroup', \OCA\mozilla_sync\User::getAuthorizedGroup());
 $tmpl->assign('mozillaSyncQuota', \OCA\mozilla_sync\User::getQuota());
+$tmpl->assign('mozillaSyncAutoCreateUser', \OCA\mozilla_sync\User::isAutoCreateUser());
 
 return $tmpl->fetchPage();
 

--- a/ajax/setautocreate.php
+++ b/ajax/setautocreate.php
@@ -1,0 +1,30 @@
+<?php
+
+// Check if this file is called by admin user, otherwise send JSON error
+\OCP\JSON::checkAdminUser();
+
+// Check if valid requesttoken was sent
+\OCP\JSON::callCheck();
+
+// Load translations
+$l = OC_L10N::get('mozilla_sync');
+
+// Get inputs and set correct settings
+$autocreate = filter_var($_POST['autocreate'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+if ($autocreate === null) {
+    // Send error message
+    \OCP\JSON::error(array( "data" => array( "message" => $l->t("Invalid input") )));
+
+} else {
+    // Update settings values
+    \OCA\mozilla_sync\User::setAutoCreateUser($autocreate);
+
+    // Send success message
+    if ( $autocreate ) {
+        \OCP\JSON::success(array( "data" => array( "message" => $l->t("Auto create sync account enabled") )));
+    } else {
+        \OCP\JSON::success(array( "data" => array( "message" => $l->t("Auto create sync account disabled") )));
+    }
+}
+
+/* vim: set ts=4 sw=4 tw=80 noet : */

--- a/js/admin.js
+++ b/js/admin.js
@@ -23,4 +23,13 @@ $(document).ready(function(){
             });
 
     });
+
+    // auto create ajax
+    $('#msautocreate').change(function() {
+        $.post(OC.filePath('mozilla_sync', 'ajax', 'setautocreate.php'),
+            { autocreate: $('#msautocreate[type=checkbox]').is(':checked') },
+            function(result){
+                showNotification(result.data.message);
+            });
+    });
 });

--- a/lib/storageservice.php
+++ b/lib/storageservice.php
@@ -37,6 +37,19 @@ class StorageService extends Service
 
 		// Get Mozilla Sync user hash and authenticate user
 		$syncHash = $this->urlParser->getSyncHash();
+
+		if ( User::isAutoCreateUser() && !User::hasSyncAccount($syncHash) ) {
+			
+			if (User::authenticateUser($syncHash, false) === false) {
+				Utils::changeHttpStatus(Utils::STATUS_INVALID_USER);
+				Utils::writeLog("Couldn't autocreate account for user " . $syncHash . " authentication failed.");
+				return false;
+			}
+
+			//auto create account
+			User::autoCreateUser($syncHash);
+		}
+
 		if (User::authenticateUser($syncHash) === false) {
 			Utils::changeHttpStatus(Utils::STATUS_INVALID_USER);
 			Utils::writeLog("Could not authenticate user " . $syncHash . ".");

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -1,4 +1,4 @@
-<div id="mozilla_sync" class="section">
+<fieldset id="mozilla_sync" class="personalblock">
     <h2><?php p($l->t('Mozilla Sync')); ?></h2>
     <p>
         <input type="checkbox" name="restrictgroup" id="restrictgroup"
@@ -27,4 +27,16 @@
         <br/>
         <em><?php p($l->t("Set the value to 0 for unlimited quota."));?></em>
     </p>
-</div>
+    <br/>
+    <p>
+        <input type="checkbox" name="msautocreate" id="msautocreate"
+            <?php if ($_['mozillaSyncAutoCreateUser']) {
+                    print_unescaped('checked="checked" ');
+                }
+            ?>
+        />
+        <label for="msautocreate"><?php p($l->t("Auto create sync account")); ?></label>
+        <br/>
+        <em><?php p($l->t("When activated, the Mozilla Sync registration API will be disabled and instead accounts will be auto created using a user's existing credentials"));?></em>
+    </p>
+</fieldset>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -1,4 +1,4 @@
-<div class="section">
+<fieldset class="personalblock">
 	<h2><?php p($l->t('Mozilla Sync')); ?></h2>
     <?php
     if (!\OCA\mozilla_sync\User::checkUserIsAllowed()) {
@@ -11,18 +11,41 @@
     <p>
       <em>
       <?php
+
         // Verify whether a Sync account was already created
         $noSync = false;
-        if (!\OCA\mozilla_sync\User::hasSyncAccount()) {
-            $noSync = true;
+
+if ( \OCA\mozilla_sync\User::isAutoCreateUser() ) {
+
+            // Create account if it does not already exist
+            if (!\OCA\mozilla_sync\User::hasSyncAccount()) {
+                //create account
+                \OCA\mozilla_sync\User::autoCreateUser();
+
+                $formatStr = "Y-m-d H:i:s T";
+                $lastMod = date($formatStr, time());
+
+            } else {
+                $lastMod = \OCA\mozilla_sync\Storage::getLastModifiedTime();
+            }
+
+            p($l->t("To use Mozilla Sync enter the credentials in to Mozilla Sync client"));
+        
         } else {
-            $lastMod = \OCA\mozilla_sync\Storage::getLastModifiedTime();
-        }
-        // Display if no account was created or no data was uploaded yet
-        if ($noSync || $lastMod === false) {
-            p($l->t("To set up Mozilla Sync create a new Sync account in Firefox."));
-        } else {
-            p($l->t("Mozilla Sync is set up, additional devices can be added via Mozilla's device pairing service or manually."));
+
+            // Verify whether a Sync account was already created
+            $noSync = false;
+            if (!\OCA\mozilla_sync\User::hasSyncAccount()) {
+                $noSync = true;
+            } else {
+                $lastMod = \OCA\mozilla_sync\Storage::getLastModifiedTime();
+            }
+            // Display if no account was created or no data was uploaded yet
+            if ($noSync || $lastMod === false) {
+                p($l->t("To set up Mozilla Sync create a new Sync account in Firefox."));
+            } else {
+                p($l->t("Mozilla Sync is set up, additional devices can be added via Mozilla's device pairing service or manually."));
+            }
         }
         ?>
         </em>
@@ -50,7 +73,7 @@
 
     <br/>
 
-    <h3><?php p($l->t('Sync Status'));?></h3>
+    <strong><?php p($l->t('Sync Status'));?></strong>
     <p>
         <?php p($l->t('Last sync:'));?>&nbsp;&nbsp;&nbsp;
         <?php p($lastMod); ?>
@@ -91,4 +114,4 @@
 
     <?php } // End: Show only when account created ?>
 
-</div>
+</fieldset>


### PR DESCRIPTION
Hi,

This changeset adds optional functionality to auto-create mozilla sync accounts using the existing ownCloud credentials.

I've been using your weave sync server to develop a client. Its been a great help, much appreciated.

--Gerry
