### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,7 @@ Helpful hints
 
 ### Firefox on Android
 
-Firefox on Android uses the ````RC4-SHA```` SSL cipher suite.
-This must be enabled on your server in order for synchronization to work with Firefox on your smartphone or tablet.
-
-If you use *nginx* you need to add  ````RC4-SHA```` to the ```ssl_ciphers``` section in your ````nginx.conf````. For more information see the [nginx documentation](http://wiki.nginx.org/HttpSslModule#ssl_ciphers).
-
-If you use *apache* you need to add ```RC4-SHA``` to the ```SSLCipherSuite``` section in your ````apache2.conf````. For more information see the [apache2 documentation](https://httpd.apache.org/docs/2.2/mod/mod_ssl.html#sslciphersuite).
+Older versions of Firefox on Android used only the ````RC4-SHA```` SSL cipher suite. This has been fixed and "TLS_DHE_RSA_WITH_AES_256_CBC_SHA" and "TLS_DHE_RSA_WITH_AES_128_CBC_SHA" have been added to Firefox 29
 
 Mozilla has a document listing the [recommended TLS ciphers](https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_Ciphersuite).
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Helpful hints
 
 ### Firefox on Android
 
-Older versions of Firefox on Android used only the ````RC4-SHA```` SSL cipher suite. This has been fixed and "TLS_DHE_RSA_WITH_AES_256_CBC_SHA" and "TLS_DHE_RSA_WITH_AES_128_CBC_SHA" have been added to Firefox 29
+Older versions of Firefox on Android used only the ````RC4-SHA```` SSL cipher suite. This has been fixed and "TLS_DHE_RSA_WITH_AES_256_CBC_SHA" and "TLS_DHE_RSA_WITH_AES_128_CBC_SHA" have been added to Firefox 29.
 
 Mozilla has a document listing the [recommended TLS ciphers](https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_Ciphersuite).
 


### PR DESCRIPTION
"TLS_DHE_RSA_WITH_AES_256_CBC_SHA" and "TLS_DHE_RSA_WITH_AES_128_CBC_SHA" have been added to the Android Sync framwork on 2013-12-21 (=Firefox 29?)

https://bugzilla.mozilla.org/show_bug.cgi?id=889749
https://hg.mozilla.org/mozilla-central/rev/589597d28687
